### PR TITLE
장르, 유저 장르 도메인 생성 및 유저 영화 장르 선호도 조사 API, 키워드 번역해 업데이트

### DIFF
--- a/movie-book/build.gradle
+++ b/movie-book/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     // Data
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'
@@ -53,11 +54,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
 
-    // redis
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+    // translate
+    implementation 'com.google.cloud:google-cloud-translate:2.0.4'
 }
 
 tasks.named('test') {

--- a/movie-book/src/main/java/hello/moviebook/Data/TranslateController.java
+++ b/movie-book/src/main/java/hello/moviebook/Data/TranslateController.java
@@ -1,0 +1,18 @@
+package hello.moviebook.Data;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/translate")
+@RequiredArgsConstructor
+public class TranslateController {
+    private final TranslateService translateService;
+
+    @PostMapping("")
+    public void translateKeywords() {
+        translateService.keywordToKo();
+    }
+}

--- a/movie-book/src/main/java/hello/moviebook/Data/TranslateService.java
+++ b/movie-book/src/main/java/hello/moviebook/Data/TranslateService.java
@@ -1,0 +1,60 @@
+package hello.moviebook.Data;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.translate.Translate;
+import com.google.cloud.translate.TranslateOptions;
+import com.google.cloud.translate.Translation;
+import hello.moviebook.Movie.Movie;
+import hello.moviebook.Movie.MovieRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.List;
+import java.io.File;
+
+@Service
+@Slf4j
+public class TranslateService {
+    private final Translate translate;
+    private final MovieRepository movieRepository;
+
+    public TranslateService(MovieRepository movieRepository) {
+        String keyPath = System.getProperty("user.home") + "/.ssh/scenic-aileron-437613-r2-d79cc15dd382.json";
+
+        try (FileInputStream serviceAccountStream = new FileInputStream(keyPath)) {
+            // 명시적으로 서비스 계정 키를 설정
+            GoogleCredentials credentials = GoogleCredentials.fromStream(serviceAccountStream);
+            TranslateOptions options = TranslateOptions.newBuilder()
+                    .setCredentials(credentials)
+                    .build();
+            this.translate = options.getService();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load Google credentials", e);
+        }
+        this.movieRepository = movieRepository;
+    }
+
+    public void keywordToKo() {
+        // 전체 영화 리스트
+        List<Movie> movieList = movieRepository.findAll();
+
+        for (Movie movie : movieList) {
+            // 해당 영화의 키워드
+            String keywords = movie.getKeyword();
+
+            // 한글로 해석된 영화의 키워드
+            Translation translation = translate.translate(keywords, Translate.TranslateOption.targetLanguage("ko"));
+
+            // 번역 키워드 출력 테스트
+            log.info("keywords : {}", translation.getTranslatedText());
+            movie.setKeywordKor(translation.getTranslatedText());
+
+            // 번역 데이터 저장
+            movieRepository.save(movie);
+        }
+
+        log.info("키워드 정보 저장 완료");
+    }
+}

--- a/movie-book/src/main/java/hello/moviebook/Jwt/SecurityConfig.java
+++ b/movie-book/src/main/java/hello/moviebook/Jwt/SecurityConfig.java
@@ -38,7 +38,8 @@ public class SecurityConfig {
         http.authorizeHttpRequests(auth -> auth
                         .requestMatchers( "/swagger-ui/**", "/v3/api-docs/**", // swagger 관련
                                 "/user/join", "/user/login", "/user/find-id", "/user/reset-pw",
-                                "/movie/tmdb-korea/{page}", "/movie/tmdb-update-en", "/movie/set-keyword"
+                                "/movie/tmdb-korea/{page}", "/movie/tmdb-update-en", "/movie/set-keyword",
+                                "/translate"
                         ).permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(new JwtAuthFilter(jwtService),

--- a/movie-book/src/main/java/hello/moviebook/Movie/Genre.java
+++ b/movie-book/src/main/java/hello/moviebook/Movie/Genre.java
@@ -1,0 +1,16 @@
+package hello.moviebook.Movie;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "genre")
+public class Genre {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "genre_number")
+    private Long genreNumber;
+
+    @Column(name = "genre_name")
+    private String genreName;
+}

--- a/movie-book/src/main/java/hello/moviebook/User/DTO/UserGenreReq.java
+++ b/movie-book/src/main/java/hello/moviebook/User/DTO/UserGenreReq.java
@@ -1,0 +1,18 @@
+package hello.moviebook.User.DTO;
+
+import lombok.Data;
+
+@Data
+public class UserGenreReq {
+    private Boolean action;
+    private Boolean drama;
+    private Boolean comedy;
+    private Boolean romance;
+    private Boolean thriller;
+    private Boolean horror;
+    private Boolean sf;
+    private Boolean fantasy;
+    private Boolean animation;
+    private Boolean documentary;
+    private Boolean crime;
+}

--- a/movie-book/src/main/java/hello/moviebook/User/User.java
+++ b/movie-book/src/main/java/hello/moviebook/User/User.java
@@ -1,6 +1,7 @@
 package hello.moviebook.User;
 
 import hello.moviebook.UserBook.UserBook;
+import hello.moviebook.UserGenre.UserGenre;
 import hello.moviebook.UserMovie.UserMovie;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -42,6 +43,9 @@ public class User {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<UserBook> userBookList;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<UserGenre> userGenreList;
 
     @Builder
     public User(String id, String password, String userName, String email) {

--- a/movie-book/src/main/java/hello/moviebook/User/UserController.java
+++ b/movie-book/src/main/java/hello/moviebook/User/UserController.java
@@ -2,8 +2,10 @@ package hello.moviebook.User;
 
 import hello.moviebook.Jwt.TokenDTO;
 import hello.moviebook.User.DTO.FindPwReq;
+import hello.moviebook.User.DTO.UserGenreReq;
 import hello.moviebook.User.DTO.UserJoinReq;
 import hello.moviebook.User.DTO.UserLoginReq;
+import hello.moviebook.UserGenre.UserGenre;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -138,6 +140,24 @@ public class UserController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("올바르지 않은 정보입니다.");
 
         return ResponseEntity.status(HttpStatus.OK).body("비밀번호를 재설정했습니다.");
+    }
+
+    @PostMapping("/genre")
+    @Operation(summary = "유저 취향 - 영화 장르", description = "유저 영화 장르 선호도 조사 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "유저 취향 장르 정보를 저장했습니다.", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "403", description = "유효성 검사 오류", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "409", description = "존재하지 않는 유저입니다.", content = @Content(mediaType = "application/json")),
+    })
+    public ResponseEntity<String> userPreferredGenre(Authentication principal, @RequestBody UserGenreReq userGenreReq) {
+        if (principal == null)
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("권한이 없는 접근입니다.");
+
+        UserGenre userGenre = userService.updateUserPreferredGenre(principal.getName(), userGenreReq);
+        if (userGenre == null)
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("존재하지 않는 유저입니다.");
+
+        return ResponseEntity.status(HttpStatus.OK).body("유저 취향 장르 정보를 저장했습니다.");
     }
 
     // 로그인 API 테스트

--- a/movie-book/src/main/java/hello/moviebook/User/UserService.java
+++ b/movie-book/src/main/java/hello/moviebook/User/UserService.java
@@ -3,8 +3,11 @@ package hello.moviebook.User;
 import hello.moviebook.Jwt.JwtService;
 import hello.moviebook.Jwt.TokenDTO;
 import hello.moviebook.User.DTO.FindPwReq;
+import hello.moviebook.User.DTO.UserGenreReq;
 import hello.moviebook.User.DTO.UserJoinReq;
 import hello.moviebook.User.DTO.UserLoginReq;
+import hello.moviebook.UserGenre.UserGenre;
+import hello.moviebook.UserGenre.UserGenreRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +26,8 @@ import java.util.Date;
 public class UserService {
 
     private final UserRepository userRepository;
+
+    private final UserGenreRepository userGenreRepository;
 
     private final PasswordEncoder passwordEncoder;
 
@@ -153,5 +158,33 @@ public class UserService {
          userRepository.save(findUser);
 
          return (findUser);
+    }
+
+    public UserGenre updateUserPreferredGenre(String userId, UserGenreReq userGenreReq) {
+        User user = userRepository.findUserById(userId);
+        UserGenre saveUserGenre = new UserGenre();
+
+        if (user == null)
+            return null;
+
+        // 유저 정보 설정
+        saveUserGenre.setUser(user);
+
+        // 유저 취향 장르 정보 설정
+        saveUserGenre.setAction(userGenreReq.getAction() != null ? userGenreReq.getAction() : false);
+        saveUserGenre.setDrama(userGenreReq.getDrama() != null ? userGenreReq.getDrama() : false);
+        saveUserGenre.setComedy(userGenreReq.getComedy() != null ? userGenreReq.getComedy() : false);
+        saveUserGenre.setRomance(userGenreReq.getRomance() != null ? userGenreReq.getRomance() : false);
+        saveUserGenre.setThriller(userGenreReq.getThriller() != null ? userGenreReq.getThriller() : false);
+        saveUserGenre.setHorror(userGenreReq.getHorror() != null ? userGenreReq.getHorror() : false);
+        saveUserGenre.setSf(userGenreReq.getSf() != null ? userGenreReq.getSf() : false);
+        saveUserGenre.setFantasy(userGenreReq.getFantasy() != null ? userGenreReq.getFantasy() : false);
+        saveUserGenre.setAnimation(userGenreReq.getAnimation() != null ? userGenreReq.getAnimation() : false);
+        saveUserGenre.setDocumentary(userGenreReq.getDocumentary() != null ? userGenreReq.getDocumentary() : false);
+        saveUserGenre.setCrime(userGenreReq.getCrime() != null ? userGenreReq.getCrime() : false);
+
+       userGenreRepository.save(saveUserGenre);
+
+       return saveUserGenre;
     }
 }

--- a/movie-book/src/main/java/hello/moviebook/UserGenre/UserGenre.java
+++ b/movie-book/src/main/java/hello/moviebook/UserGenre/UserGenre.java
@@ -1,0 +1,52 @@
+package hello.moviebook.UserGenre;
+
+import hello.moviebook.User.User;
+import jakarta.persistence.*;
+import lombok.Setter;
+
+@Entity
+@Table(name = "user_genre")
+@Setter
+public class UserGenre {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_genre_number")
+    private Long userGenreNumber;
+
+    @Column(name = "action", nullable = false)
+    private Boolean action;
+
+    @Column(name = "drama", nullable = false)
+    private Boolean drama;
+
+    @Column(name = "comedy", nullable = false)
+    private Boolean comedy;
+
+    @Column(name = "romance", nullable = false)
+    private Boolean romance;
+
+    @Column(name = "thriller", nullable = false)
+    private Boolean thriller;
+
+    @Column(name = "horror", nullable = false)
+    private Boolean horror;
+
+    @Column(name = "sf", nullable = false)
+    private Boolean sf;
+
+    @Column(name = "fantasy", nullable = false)
+    private Boolean fantasy;
+
+    @Column(name = "animation", nullable = false)
+    private Boolean animation;
+
+    @Column(name = "documentary", nullable = false)
+    private Boolean documentary;
+
+    @Column(name = "crime", nullable = false)
+    private Boolean crime;
+
+    @ManyToOne
+    @JoinColumn(name = "user_number")
+    private User user;
+}

--- a/movie-book/src/main/java/hello/moviebook/UserGenre/UserGenreRepository.java
+++ b/movie-book/src/main/java/hello/moviebook/UserGenre/UserGenreRepository.java
@@ -1,0 +1,8 @@
+package hello.moviebook.UserGenre;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserGenreRepository extends JpaRepository<UserGenre, Long> {
+}


### PR DESCRIPTION
## 도메인 생성
### Genre
11가지 종류의 컬럼 가진 Genre 테이블 생성

### UserGenre
유저_장르_번호, 유저_번호, 각 장르 Boolean 값으로 들고 있는 UserGenre 테이블 생성

## 키워드 문자열 번역해 업데이트
GCP Translate API 활용해 영어 키워드 문자열 번역해 키워드_ko 업데이트
- API 키 파일 다운 받아서 .zshrc 파일에 export 통해 환경 변수화

## 유저 영화 장르 선호도 조사 API
1. Access Token 정보 확인 -> 유저 권한 확인
2. @RequestBody 통해 유저의 장르 별 선호도 조사
3. 유저 장르 취향 정보 저장