### PR TITLE
[Feat] 친구 관련 API 구현

### DIFF
--- a/movie-book/src/main/java/hello/moviebook/User/domain/User.java
+++ b/movie-book/src/main/java/hello/moviebook/User/domain/User.java
@@ -1,6 +1,7 @@
 package hello.moviebook.user.domain;
 
 import hello.moviebook.book.domain.UserBook;
+import hello.moviebook.friend.domain.Friend;
 import hello.moviebook.movie.domain.UserDislikeGenre;
 import hello.moviebook.movie.domain.UserLikeGenre;
 import hello.moviebook.movie.domain.UserMovie;
@@ -50,6 +51,12 @@ public class User {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<UserLikeGenre> userLikeGenreList;
+
+    @OneToMany(mappedBy = "user1", cascade = CascadeType.ALL)
+    private List<Friend> friendUserOne;
+
+    @OneToMany(mappedBy = "user2", cascade = CascadeType.ALL)
+    private List<Friend> friendUserTwo;
 
     @Builder
     public User(String id, String password, String name, String email) {

--- a/movie-book/src/main/java/hello/moviebook/book/dto/BookDTO.java
+++ b/movie-book/src/main/java/hello/moviebook/book/dto/BookDTO.java
@@ -1,0 +1,11 @@
+package hello.moviebook.book.dto;
+
+import lombok.Getter;
+
+@Getter
+public class BookDTO {
+    private String name;
+    private String image;
+    private Double rating;
+    private String review;
+}

--- a/movie-book/src/main/java/hello/moviebook/book/dto/BookDTO.java
+++ b/movie-book/src/main/java/hello/moviebook/book/dto/BookDTO.java
@@ -1,5 +1,7 @@
 package hello.moviebook.book.dto;
 
+import hello.moviebook.book.domain.UserBook;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -8,4 +10,12 @@ public class BookDTO {
     private String image;
     private Double rating;
     private String review;
+
+    @Builder
+    public BookDTO(UserBook userBook) {
+        this.name = userBook.getBook().getBookName();
+        this.image = userBook.getBook().getImage();
+        this.rating = userBook.getBookRating();
+        this.review = userBook.getBookReview();
+    }
 }

--- a/movie-book/src/main/java/hello/moviebook/book/repository/UserBookRepository.java
+++ b/movie-book/src/main/java/hello/moviebook/book/repository/UserBookRepository.java
@@ -1,0 +1,11 @@
+package hello.moviebook.book.repository;
+
+import hello.moviebook.book.domain.UserBook;
+import hello.moviebook.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserBookRepository extends JpaRepository<UserBook, Long> {
+    List<UserBook> findAllByUser(User user);
+}

--- a/movie-book/src/main/java/hello/moviebook/friend/controller/FriendController.java
+++ b/movie-book/src/main/java/hello/moviebook/friend/controller/FriendController.java
@@ -4,6 +4,8 @@ import hello.moviebook.friend.dto.FriendBookListRes;
 import hello.moviebook.friend.dto.FriendListRes;
 import hello.moviebook.friend.dto.FriendReq;
 import hello.moviebook.friend.service.FriendService;
+import hello.moviebook.user.domain.User;
+import hello.moviebook.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,9 +19,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FriendController {
     private final FriendService friendService;
+    private final UserRepository userRepository;
 
-    @GetMapping("/{userNumber}")
-    public ResponseEntity<List<FriendListRes>> getFriendList(Authentication authentication, @PathVariable("userNumber") Long userNumber) {
+    @GetMapping("")
+    public ResponseEntity<List<FriendListRes>> getFriendList(Authentication authentication) {
         if (authentication == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
         }
@@ -50,10 +53,17 @@ public class FriendController {
         return ResponseEntity.status(HttpStatus.OK).body(friendReq.getId() + "님을 친구 목록에서 삭제했습니다.");
     }
 
-    @GetMapping("/{userNumber}/book")
-    public ResponseEntity<FriendBookListRes> getFriendBookList(Authentication authentication, @PathVariable("userNumber") Long userNumber) {
+    @GetMapping("/{id}/book")
+    public ResponseEntity<FriendBookListRes> getFriendBookList(Authentication authentication, @PathVariable("id") String id) {
         if (authentication == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
         }
+
+        User friend = userRepository.findUserById(id);
+        if (friend == null)
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
+
+        FriendBookListRes friendBookList = friendService.getFriendBookList(friend);
+        return ResponseEntity.status(HttpStatus.OK).body(friendBookList);
     }
 }

--- a/movie-book/src/main/java/hello/moviebook/friend/controller/FriendController.java
+++ b/movie-book/src/main/java/hello/moviebook/friend/controller/FriendController.java
@@ -1,0 +1,55 @@
+package hello.moviebook.friend.controller;
+
+import hello.moviebook.friend.dto.FriendBookListRes;
+import hello.moviebook.friend.dto.FriendListRes;
+import hello.moviebook.friend.dto.FriendReq;
+import hello.moviebook.friend.service.FriendService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/friend")
+@RequiredArgsConstructor
+public class FriendController {
+    private final FriendService friendService;
+
+    @GetMapping("/{userNumber}")
+    public ResponseEntity<FriendListRes> getFriendList(Authentication authentication, @PathVariable("userNumber") Long userNumber) {
+        if (authentication == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
+        }
+
+    }
+
+    @PostMapping("/add")
+    public ResponseEntity<String> postNewFriend(Authentication authentication, @RequestBody FriendReq friendReq) {
+        if (authentication == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
+        }
+
+        if (!friendService.addFriend(authentication.getName(), friendReq.getId()))
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(friendReq.getId() + "님을 친구 추가에 실패했습니다.");
+        return ResponseEntity.status(HttpStatus.OK).body(friendReq.getId() + "님을 친구 목록에 추가했습니다.");
+    }
+
+    @PatchMapping("/delete")
+    public ResponseEntity<String> patchFriendList(Authentication authentication, @RequestBody FriendReq friendReq) {
+        if (authentication == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
+        }
+
+        if (!friendService.deleteFriend(authentication.getName(), friendReq.getId()))
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(friendReq.getId() + "님을 친구 삭제에 실패했습니다.");
+        return ResponseEntity.status(HttpStatus.OK).body(friendReq.getId() + "님을 친구 목록에서 삭제했습니다.");
+    }
+
+    @GetMapping("/{userNumber}/book")
+    public ResponseEntity<FriendBookListRes> getFriendBookList(Authentication authentication, @PathVariable("userNumber") Long userNumber) {
+        if (authentication == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
+        }
+    }
+}

--- a/movie-book/src/main/java/hello/moviebook/friend/controller/FriendController.java
+++ b/movie-book/src/main/java/hello/moviebook/friend/controller/FriendController.java
@@ -10,18 +10,22 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
-@RequestMapping("/friend")
+@RequestMapping("/api/v1/friend")
 @RequiredArgsConstructor
 public class FriendController {
     private final FriendService friendService;
 
     @GetMapping("/{userNumber}")
-    public ResponseEntity<FriendListRes> getFriendList(Authentication authentication, @PathVariable("userNumber") Long userNumber) {
+    public ResponseEntity<List<FriendListRes>> getFriendList(Authentication authentication, @PathVariable("userNumber") Long userNumber) {
         if (authentication == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
         }
 
+        List<FriendListRes> friendList = friendService.getFriends(authentication.getName());
+        return ResponseEntity.status(HttpStatus.OK).body(friendList);
     }
 
     @PostMapping("/add")

--- a/movie-book/src/main/java/hello/moviebook/friend/domain/Friend.java
+++ b/movie-book/src/main/java/hello/moviebook/friend/domain/Friend.java
@@ -3,9 +3,13 @@ package hello.moviebook.friend.domain;
 import hello.moviebook.user.domain.User;
 import jakarta.persistence.*;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "friend")
+@Getter
+@NoArgsConstructor
 public class Friend {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/movie-book/src/main/java/hello/moviebook/friend/domain/Friend.java
+++ b/movie-book/src/main/java/hello/moviebook/friend/domain/Friend.java
@@ -1,0 +1,33 @@
+package hello.moviebook.friend.domain;
+
+import hello.moviebook.user.domain.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+
+@Entity
+@Table(name = "friend")
+public class Friend {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long friendNumber;
+
+    @ManyToOne
+    @JoinColumn(name = "user1")
+    private User user1;
+
+    @ManyToOne
+    @JoinColumn(name = "user2")
+    private User user2;
+
+    @Builder
+    public Friend(User user1, User user2) {
+        if (user1.getId().compareTo(user2.getId()) < 0) {
+            this.user1 = user1;
+            this.user2 = user2;
+        }
+        else {
+            this.user1 = user2;
+            this.user2 = user1;
+        }
+    }
+}

--- a/movie-book/src/main/java/hello/moviebook/friend/dto/FriendBookListRes.java
+++ b/movie-book/src/main/java/hello/moviebook/friend/dto/FriendBookListRes.java
@@ -1,0 +1,12 @@
+package hello.moviebook.friend.dto;
+
+import hello.moviebook.book.dto.BookDTO;
+
+import java.util.List;
+
+public class FriendBookListRes {
+    private String id;
+    private String name;
+
+    List<BookDTO> bookList;
+}

--- a/movie-book/src/main/java/hello/moviebook/friend/dto/FriendBookListRes.java
+++ b/movie-book/src/main/java/hello/moviebook/friend/dto/FriendBookListRes.java
@@ -1,12 +1,24 @@
 package hello.moviebook.friend.dto;
 
+import hello.moviebook.book.domain.UserBook;
 import hello.moviebook.book.dto.BookDTO;
+import hello.moviebook.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
 
 import java.util.List;
 
+@Getter
 public class FriendBookListRes {
     private String id;
-    private String name;
 
-    List<BookDTO> bookList;
+    private List<BookDTO> bookList;
+
+    @Builder
+    public FriendBookListRes(User user, List<UserBook> userBookList) {
+        this.id = user.getId();
+        this.bookList = userBookList.stream()
+                .map(BookDTO::new)
+                .toList();
+    }
 }

--- a/movie-book/src/main/java/hello/moviebook/friend/dto/FriendListRes.java
+++ b/movie-book/src/main/java/hello/moviebook/friend/dto/FriendListRes.java
@@ -1,6 +1,23 @@
 package hello.moviebook.friend.dto;
 
+import hello.moviebook.friend.domain.Friend;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
 public class FriendListRes {
     private String id;
     private String name;
+
+    @Builder
+    public FriendListRes(String userId, Friend friend) {
+        if (friend.getUser1().getId().equals(userId)) {
+            this.id = friend.getUser2().getId();
+            this.name = friend.getUser2().getId();
+        }
+        else {
+            this.id = friend.getUser1().getId();
+            this.name = friend.getUser1().getId();
+        }
+    }
 }

--- a/movie-book/src/main/java/hello/moviebook/friend/dto/FriendListRes.java
+++ b/movie-book/src/main/java/hello/moviebook/friend/dto/FriendListRes.java
@@ -7,17 +7,14 @@ import lombok.Getter;
 @Getter
 public class FriendListRes {
     private String id;
-    private String name;
 
     @Builder
     public FriendListRes(String userId, Friend friend) {
         if (friend.getUser1().getId().equals(userId)) {
             this.id = friend.getUser2().getId();
-            this.name = friend.getUser2().getId();
         }
         else {
             this.id = friend.getUser1().getId();
-            this.name = friend.getUser1().getId();
         }
     }
 }

--- a/movie-book/src/main/java/hello/moviebook/friend/dto/FriendListRes.java
+++ b/movie-book/src/main/java/hello/moviebook/friend/dto/FriendListRes.java
@@ -1,0 +1,6 @@
+package hello.moviebook.friend.dto;
+
+public class FriendListRes {
+    private String id;
+    private String name;
+}

--- a/movie-book/src/main/java/hello/moviebook/friend/dto/FriendReq.java
+++ b/movie-book/src/main/java/hello/moviebook/friend/dto/FriendReq.java
@@ -1,0 +1,8 @@
+package hello.moviebook.friend.dto;
+
+import lombok.Getter;
+
+@Getter
+public class FriendReq {
+    private String id;
+}

--- a/movie-book/src/main/java/hello/moviebook/friend/repository/FriendRepository.java
+++ b/movie-book/src/main/java/hello/moviebook/friend/repository/FriendRepository.java
@@ -4,6 +4,9 @@ import hello.moviebook.friend.domain.Friend;
 import hello.moviebook.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface FriendRepository extends JpaRepository<Friend, Long> {
     Friend findByUser1AndUser2(User user1, User user2);
+    List<Friend> findAllByUser1OrUser2(User user1, User user2);
 }

--- a/movie-book/src/main/java/hello/moviebook/friend/repository/FriendRepository.java
+++ b/movie-book/src/main/java/hello/moviebook/friend/repository/FriendRepository.java
@@ -1,0 +1,9 @@
+package hello.moviebook.friend.repository;
+
+import hello.moviebook.friend.domain.Friend;
+import hello.moviebook.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FriendRepository extends JpaRepository<Friend, Long> {
+    Friend findByUser1AndUser2(User user1, User user2);
+}

--- a/movie-book/src/main/java/hello/moviebook/friend/service/FriendService.java
+++ b/movie-book/src/main/java/hello/moviebook/friend/service/FriendService.java
@@ -1,0 +1,29 @@
+package hello.moviebook.friend.service;
+
+import hello.moviebook.friend.domain.Friend;
+import hello.moviebook.friend.repository.FriendRepository;
+import hello.moviebook.user.domain.User;
+import hello.moviebook.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FriendService {
+    private final UserRepository userRepository;
+    private final FriendRepository friendRepository;
+
+    public boolean addFriend(String userId, String friendId) {
+        User user = userRepository.findUserById(userId);
+        User friend = userRepository.findUserById(friendId);
+
+        if (user == null || friend == null)
+            return false;
+
+        Friend newFriend = new Friend(user, friend);
+        friendRepository.save(newFriend);
+
+        return true;
+    }
+
+}

--- a/movie-book/src/main/java/hello/moviebook/friend/service/FriendService.java
+++ b/movie-book/src/main/java/hello/moviebook/friend/service/FriendService.java
@@ -1,6 +1,9 @@
 package hello.moviebook.friend.service;
 
+import hello.moviebook.book.domain.UserBook;
+import hello.moviebook.book.repository.UserBookRepository;
 import hello.moviebook.friend.domain.Friend;
+import hello.moviebook.friend.dto.FriendBookListRes;
 import hello.moviebook.friend.dto.FriendListRes;
 import hello.moviebook.friend.repository.FriendRepository;
 import hello.moviebook.user.domain.User;
@@ -14,6 +17,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FriendService {
     private final UserRepository userRepository;
+    private final UserBookRepository userBookRepository;
     private final FriendRepository friendRepository;
 
     public List<FriendListRes> getFriends(String userId) {
@@ -54,5 +58,14 @@ public class FriendService {
         }
 
         return true;
+    }
+
+    public FriendBookListRes getFriendBookList(User friend) {
+        List<UserBook> userBookList = userBookRepository.findAllByUser(friend);
+
+        return FriendBookListRes.builder()
+                    .user(friend)
+                    .userBookList(userBookList)
+                    .build();
     }
 }

--- a/movie-book/src/main/java/hello/moviebook/friend/service/FriendService.java
+++ b/movie-book/src/main/java/hello/moviebook/friend/service/FriendService.java
@@ -1,17 +1,31 @@
 package hello.moviebook.friend.service;
 
 import hello.moviebook.friend.domain.Friend;
+import hello.moviebook.friend.dto.FriendListRes;
 import hello.moviebook.friend.repository.FriendRepository;
 import hello.moviebook.user.domain.User;
 import hello.moviebook.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class FriendService {
     private final UserRepository userRepository;
     private final FriendRepository friendRepository;
+
+    public List<FriendListRes> getFriends(String userId) {
+        User user = userRepository.findUserById(userId);
+
+        return friendRepository.findAllByUser1OrUser2(user, user).stream()
+                .map(friend -> FriendListRes.builder()
+                        .userId(userId)
+                        .friend(friend)
+                        .build())
+                .toList();
+    }
 
     public boolean addFriend(String userId, String friendId) {
         User user = userRepository.findUserById(userId);

--- a/movie-book/src/main/java/hello/moviebook/friend/service/FriendService.java
+++ b/movie-book/src/main/java/hello/moviebook/friend/service/FriendService.java
@@ -26,4 +26,19 @@ public class FriendService {
         return true;
     }
 
+    public boolean deleteFriend(String userId, String friendId) {
+        User user = userRepository.findUserById(userId);
+        User friend = userRepository.findUserById(friendId);
+
+        if (user == null || friend == null)
+            return false;
+
+        if (userId.compareTo(friendId) < 0) {
+            friendRepository.delete(friendRepository.findByUser1AndUser2(user, friend));
+        } else {
+            friendRepository.delete(friendRepository.findByUser1AndUser2(friend, user));
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
## 친구 관련 API 구현

### 친구 리스트 조회 API
유저 id를 통해 유저와 친구 관계를 맺고 있는 친구 리스트를 불러오는 로직을 구현했습니다.
리스트를 효율적으로 생성하기 위해 FriendListRes에 Builder를 추가했습니다.

### 친구 도서 리스트 조회 API
친구 id를 통해 친구의 추천 도서 리스트를 불러오는 로직을 구현했습니다.
응답으로 FriendBookListRes를 리턴하고, 이는 친구 id, List<BookDTO>를 담고있습니다.
BookDTO는 도서명, 도서 이미지, 도서 평점, 도서 리뷰를 담고있습니다.

### 친구 추가 API
유저, 친구 id를 통해 친구 관계를 생성하는 로직을 구현했습니다.

### 친구 삭제 API
유저, 친구 id를 통해 친구 관계를 삭제하는 로직을 구현했습니다.