### PR TITLE
[Refactor] Friend 삭제 로직 수정

### DIFF
--- a/movie-book/src/main/java/hello/moviebook/friend/controller/FriendControllerImpl.java
+++ b/movie-book/src/main/java/hello/moviebook/friend/controller/FriendControllerImpl.java
@@ -56,7 +56,6 @@ public class FriendControllerImpl implements FriendController{
         if (friend == null)
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("존재하지 않는 유저입니다.");
 
-
         if (!friendService.deleteFriend(userRepository.findUserById(authentication.getName()), friend))
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(friendReq.getId() + "님과 친구 관계가 아닙니다.");
         return ResponseEntity.status(HttpStatus.OK).body(friendReq.getId() + "님을 친구 목록에서 삭제했습니다.");

--- a/movie-book/src/main/java/hello/moviebook/friend/service/FriendService.java
+++ b/movie-book/src/main/java/hello/moviebook/friend/service/FriendService.java
@@ -46,16 +46,17 @@ public class FriendService {
     }
 
     public boolean deleteFriend(User user, User friend) {
+        Friend relation;
 
-        if (user.getNumber().compareTo(friend.getNumber()) < 0) {
-            if (friendRepository.findByUser1AndUser2(friend, user) == null)
-                return false;
-            friendRepository.delete(friendRepository.findByUser1AndUser2(user, friend));
-        } else {
-            if (friendRepository.findByUser1AndUser2(user, friend) == null)
-                return false;
-            friendRepository.delete(friendRepository.findByUser1AndUser2(friend, user));
-        }
+        if (user.getNumber() < friend.getNumber())
+            relation = friendRepository.findByUser1AndUser2(user, friend);
+        else
+            relation = friendRepository.findByUser1AndUser2(friend, user);
+
+        if (relation == null)
+            return false;
+
+        friendRepository.delete(relation);
 
         return true;
     }


### PR DESCRIPTION
## Friend 삭제 로직 수정

친구 관계 생성시 유저 번호가 작은 쪽이 user1, 큰 쪽이 user2에 저장되게 됩니다. 
그러나 삭제 로직 수행시 반대로 삭제를 수행하여 에러가 발생했습니다. 이를 해결하기 위해 삭제 로직을 수정했습니다.

