### PR TITLE
[Feat] 도서 추천 API 구현

### DIFF
--- a/movie-book/build.gradle
+++ b/movie-book/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     // Data
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/movie-book/src/main/java/hello/moviebook/Movie/DTO/MovieRatingReq.java
+++ b/movie-book/src/main/java/hello/moviebook/Movie/DTO/MovieRatingReq.java
@@ -5,5 +5,5 @@ import lombok.Getter;
 @Getter
 public class MovieRatingReq {
     private Long movieId;
-    private Double rating;
+    private Long rating;
 }

--- a/movie-book/src/main/java/hello/moviebook/Movie/DTO/UserMovieRes.java
+++ b/movie-book/src/main/java/hello/moviebook/Movie/DTO/UserMovieRes.java
@@ -15,7 +15,7 @@ public class UserMovieRes {
     private Long movieId;
     private String movieName;
     private String poster;
-    private Double rating;
+    private Long rating;
 
     public static UserMovieRes defaultBuilder(UserMovie userMovie, Movie movie) {
         return UserMovieRes.builder()

--- a/movie-book/src/main/java/hello/moviebook/Movie/domain/Genre.java
+++ b/movie-book/src/main/java/hello/moviebook/Movie/domain/Genre.java
@@ -15,6 +15,8 @@ public class Genre {
     private Long number;
     @Column(name = "name")
     private String name;
+    @Column(name = "name_en")
+    private String nameEn;
 
     @OneToMany(mappedBy = "genre", cascade = CascadeType.ALL)
     private List<UserDislikeGenre> userDislikeGenreList;

--- a/movie-book/src/main/java/hello/moviebook/Movie/domain/UserMovie.java
+++ b/movie-book/src/main/java/hello/moviebook/Movie/domain/UserMovie.java
@@ -17,8 +17,7 @@ public class UserMovie {
     private Long number;
 
     @Column(name = "rating")
-    private Double rating;
-
+    private Long rating;
     @ManyToOne
     @JoinColumn(name = "user_number")
     private User user;
@@ -27,7 +26,7 @@ public class UserMovie {
     @JoinColumn(name = "movie_number")
     private Movie movie;
 
-    public UserMovie(User user, Movie movie, Double rating) {
+    public UserMovie(User user, Movie movie, Long rating) {
         this.user = user;
         this.movie = movie;
         this.rating = rating;

--- a/movie-book/src/main/java/hello/moviebook/Movie/service/MovieService.java
+++ b/movie-book/src/main/java/hello/moviebook/Movie/service/MovieService.java
@@ -96,10 +96,10 @@ public class MovieService {
         return userMovieResList;
     }
 
-    private Double getMovieRating(Movie movie, List<UserMovie> userMovieList) {
+    private Long getMovieRating(Movie movie, List<UserMovie> userMovieList) {
         return userMovieList.stream()
                 .filter(usermovie -> usermovie.getMovie().equals(movie))
                 .map(UserMovie::getRating)
-                .findFirst().orElse(0.0);
+                .findFirst().orElse(0L);
     }
 }

--- a/movie-book/src/main/java/hello/moviebook/book/controller/BookController.java
+++ b/movie-book/src/main/java/hello/moviebook/book/controller/BookController.java
@@ -1,6 +1,7 @@
 package hello.moviebook.book.controller;
 
 import hello.moviebook.book.dto.BookDescriptRes;
+import hello.moviebook.book.dto.RecommendBookRes;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -12,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
-public interface UserBookController {
+public interface BookController {
     @Operation(summary = "줄거리 키워드 기반 도서 검색", description = "줄거리 키워드 기반 도서 검색 API")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "줄거리 키워드 기반으로 도서 정보를 검색했습니다.", content = @Content(mediaType = "application/json")),
@@ -27,4 +28,12 @@ public interface UserBookController {
             @ApiResponse(responseCode = "400", description = "존재하지 않는 유저입니다.", content = @Content(mediaType = "application/json")),
     })
     public ResponseEntity<List<BookDescriptRes>> getKeywordBookList(Authentication authentication);
+
+    @Operation(summary = "사용자 맞춤 추천 도서 리스트", description = "사용자 맞춤 추천 도서 리스트 제공 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "추천 도서 리스트입니다.", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "403", description = "잘못된 로그인입니다.", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "400", description = "도서 리스트 추천에 실패했습니다.", content = @Content(mediaType = "application/json")),
+    })
+    public ResponseEntity<List<RecommendBookRes>> getRecommendBookList(Authentication authentication);
 }

--- a/movie-book/src/main/java/hello/moviebook/book/controller/BookControllerImpl.java
+++ b/movie-book/src/main/java/hello/moviebook/book/controller/BookControllerImpl.java
@@ -1,7 +1,9 @@
 package hello.moviebook.book.controller;
 
 import hello.moviebook.book.dto.BookDescriptRes;
+import hello.moviebook.book.dto.RecommendBookRes;
 import hello.moviebook.book.service.BookService;
+import hello.moviebook.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,8 +18,9 @@ import java.util.List;
 @Controller
 @RequestMapping("/api/v1/book")
 @RequiredArgsConstructor
-public class UserBookControllerImpl {
+public class BookControllerImpl {
     private final BookService bookService;
+    private final UserRepository userRepository;
 
     // 줄거리 키워드 기반 도서 검색
     @GetMapping("/search-descript")
@@ -29,5 +32,17 @@ public class UserBookControllerImpl {
     @GetMapping("/search-keyword")
     public ResponseEntity<List<BookDescriptRes>> getKeywordBookList(Authentication authentication) {
         return ResponseEntity.status(HttpStatus.OK).body(bookService.getBookListByMovieKeywords(authentication.getName()));
+    }
+
+    // 사용자 맞춤 추천 도서 리스트
+    @GetMapping("/recommend")
+    public ResponseEntity<List<RecommendBookRes>> getRecommendBookList(Authentication authentication) {
+        if (authentication == null)
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
+
+        List<RecommendBookRes> recBookList = bookService.getRecommendBookList(userRepository.findUserById(authentication.getName()));
+        if (recBookList == null)
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+        return ResponseEntity.status(HttpStatus.OK).body(recBookList);
     }
 }

--- a/movie-book/src/main/java/hello/moviebook/book/dto/FlaskReqDTO.java
+++ b/movie-book/src/main/java/hello/moviebook/book/dto/FlaskReqDTO.java
@@ -1,0 +1,16 @@
+package hello.moviebook.book.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class FlaskReqDTO {
+    private List<String> userLikeGenreList;
+    private List<String> userDislikeGenreList;
+    private List<Long> movieList;
+    private List<Long> ratingList;
+    private Long nBooks;
+}

--- a/movie-book/src/main/java/hello/moviebook/book/dto/FlaskResDTO.java
+++ b/movie-book/src/main/java/hello/moviebook/book/dto/FlaskResDTO.java
@@ -1,0 +1,12 @@
+package hello.moviebook.book.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FlaskResDTO {
+    @JsonProperty("book_name")
+    private String bookName;
+}

--- a/movie-book/src/main/java/hello/moviebook/book/dto/RecommendBookRes.java
+++ b/movie-book/src/main/java/hello/moviebook/book/dto/RecommendBookRes.java
@@ -1,0 +1,21 @@
+package hello.moviebook.book.dto;
+
+import hello.moviebook.book.domain.Book;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class RecommendBookRes {
+    String isbn;
+    String bookName;
+    String description;
+    String image;
+
+    @Builder
+    public RecommendBookRes(Book book) {
+        this.isbn = book.getIsbn();
+        this.bookName = book.getBookName();
+        this.description = book.getDescription();
+        this.image = book.getImage();
+    }
+}

--- a/movie-book/src/main/java/hello/moviebook/book/service/BookService.java
+++ b/movie-book/src/main/java/hello/moviebook/book/service/BookService.java
@@ -2,25 +2,29 @@ package hello.moviebook.book.service;
 
 import hello.moviebook.book.domain.Book;
 import hello.moviebook.book.dto.BookDescriptRes;
+import hello.moviebook.book.dto.FlaskReqDTO;
+import hello.moviebook.book.dto.RecommendBookRes;
 import hello.moviebook.book.repository.BookRepository;
 import hello.moviebook.book.repository.BookSpecifications;
 import hello.moviebook.movie.domain.UserLikeGenre;
 import hello.moviebook.movie.domain.UserMovie;
+import hello.moviebook.movie.repository.UserDislikeGenreRepository;
 import hello.moviebook.movie.repository.UserLikeGenreRepository;
 import hello.moviebook.movie.repository.UserMovieRepository;
 import hello.moviebook.user.domain.User;
 import hello.moviebook.user.repository.UserRepository;
+import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -31,6 +35,15 @@ public class BookService {
     private final UserMovieRepository userMovieRepository;
     private final UserRepository userRepository;
     private final UserLikeGenreRepository userLikeGenreRepository;
+    private final UserDislikeGenreRepository userDislikeGenreRepository;
+    private final WebClient.Builder webClientBuilder;
+    private WebClient webClient;
+
+    @PostConstruct
+    public void init() {
+        this.webClient = webClientBuilder.baseUrl("http://35.216.42.151:5000").build();
+    }
+
     @PersistenceContext  // EntityManager 주입
     private EntityManager entityManager;
 
@@ -46,7 +59,7 @@ public class BookService {
         User user = userRepository.findUserById(id);
         List<UserLikeGenre> userLikeGenres = userLikeGenreRepository.findAllByUser(user);
         List<UserMovie> userMovieTopList = userMovieRepository.findAllByUser(user).stream()
-                .filter(userMovie -> userMovie.getRating().compareTo(4.0) >= 0)
+                .filter(userMovie -> userMovie.getRating().compareTo(4L) >= 0)
                 .toList();
         List<String> topKeywords = new ArrayList<>();
 
@@ -95,5 +108,60 @@ public class BookService {
                 .limit(topN)
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toList());
+    }
+
+    public List<RecommendBookRes> getRecommendBookList(User user) {
+        FlaskReqDTO flaskReqDTO = createFlaskReq(user);
+
+        // Flask API URL
+        String flaskUrl = "/rec-book";
+
+        // 요청 데이터 생성
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("prefer_genre", flaskReqDTO.getUserLikeGenreList());   // 선호 장르
+        requestBody.put("dislike_genre", flaskReqDTO.getUserDislikeGenreList());  // 비선호 장르
+        requestBody.put("movie_index", flaskReqDTO.getMovieList());      // 영화 인덱스
+        requestBody.put("rating", flaskReqDTO.getRatingList());                // 영화 평점
+        requestBody.put("n_books", flaskReqDTO.getNBooks());
+
+        log.info("Movie prefer_genre : {}", flaskReqDTO.getUserLikeGenreList());
+        log.info("Movie dislike_genre : {}", flaskReqDTO.getUserDislikeGenreList());
+        log.info("Movie idx : {}", flaskReqDTO.getMovieList());
+        log.info("Movie rating : {}", flaskReqDTO.getRatingList());
+        log.info("nbooks : {}", flaskReqDTO.getNBooks());
+
+        return createRecBookList(webClient.post()
+                .uri(flaskUrl)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .bodyValue(requestBody)
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<List<String>>() {})
+                .block());
+    }
+
+    private FlaskReqDTO createFlaskReq(User user) {
+        Long nBooks = 10L;
+        List<String> userLikeGenres = userLikeGenreRepository.findAllByUser(user).stream()
+                .map(userLikeGenre -> userLikeGenre.getGenre().getNameEn())
+                .toList();
+        List<String> userDislikeGenres = userDislikeGenreRepository.findAllByUser(user).stream()
+                .map(userDislikeGenre -> userDislikeGenre.getGenre().getNameEn())
+                .toList();
+        List<Long> movieList = userMovieRepository.findAllByUser(user).stream()
+                .map(userMovie -> userMovie.getMovie().getMovieId())
+                .toList();
+        List<Long> ratingList = userMovieRepository.findAllByUser(user).stream()
+                .map(UserMovie::getRating)
+                .toList();
+
+        return new FlaskReqDTO(userLikeGenres, userDislikeGenres, movieList, ratingList, nBooks);
+    }
+
+    private List<RecommendBookRes> createRecBookList(List<String> recBookList) {
+        return recBookList.stream()
+                .map(bookRepository::findBookByBookName)
+                .filter(Objects::nonNull)
+                .map(RecommendBookRes::new)
+                .toList();
     }
 }

--- a/movie-book/src/main/java/hello/moviebook/config/AppConfig.java
+++ b/movie-book/src/main/java/hello/moviebook/config/AppConfig.java
@@ -1,0 +1,13 @@
+package hello.moviebook.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class AppConfig {
+    @Bean
+    public WebClient.Builder webClientBuilder() {
+        return WebClient.builder();
+    }
+}


### PR DESCRIPTION
## #51 도서 추천 API 구현 

### 추천 시스템
파이썬으로 구현한 추천 시스템 코드를 Flask API로 백엔드 서버와 같은 주소로 /rec-book 엔드포인트로 배포했습니다.
요청시 유저 선호 및 불호 장르 리스트, 관람 영화 ID 리스트, 영화 평점 리스트, 추천 도서 개수를 건네받습니다.
응답으로 추천 도서명 리스트를 응답합니다.

### Spring
Flask API 요청시 필요한 Genre, Rating 관련 내용을 수정했습니다.
추천 도서명을 기반으로 응답시 사용할 DTO를 생성해 리턴합니다.